### PR TITLE
[FEAT] - 책 상세 페이지 API 연동 세팅

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,34 +1,39 @@
 name: Deploy
 
 on:
-    push:
-        branches: ['main']
+  push:
+    branches: ['main']
 
 jobs:
-    build:
-        runs-on: ubuntu-latest
-        container: pandoc/latex
-        steps:
-            - uses: actions/checkout@v2
+  build:
+    runs-on: ubuntu-latest
+    container: pandoc/latex
+    steps:
+      - uses: actions/checkout@v2
 
-            - name: Install mustache (to update the date)
-              run: apk add ruby && gem install mustache
+      - name: Install mustache (to update the date)
+        run: apk add ruby && gem install mustache
 
-            - name: creates output
-              run: sh ./build.sh
+      - name: creates output
+        run: sh ./build.sh
 
-            - name: Pushes to another repository
-              id: push_directory
-              uses: cpina/github-action-push-to-another-repository@main
-              env:
-                  API_TOKEN_GITHUB: ${{ secrets.AUTO_ACTIONS }}
-              with:
-                  source-directory: 'output'
-                  destination-github-username: 'karpitony'
-                  destination-repository-name: 'Booklog-Frontend-Deploy'
-                  user-email: ${{ secrets.EMAIL }}
-                  commit-message: ${{ github.event.commits[0].message }}
-                  target-branch: main
+      - name: Pushes to another repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.AUTO_ACTIONS }}
+          VITE_NAVER_CLIENT_ID: ${{ secrets.VITE_NAVER_CLIENT_ID }}
+          VITE_NAVER_CLIENT_SECRET: ${{ secrets.VITE_NAVER_CLIENT_SECRET }}
+        with:
+          source-directory: 'output'
+          destination-github-username: 'karpitony'
+          destination-repository-name: 'Booklog-Frontend-Deploy'
+          user-email: ${{ secrets.EMAIL }}
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: main
 
-            - name: Test get variable exported by push-to-another-repository
-              run: echo $DESTINATION_CLONED_DIRECTORY
+      - name: Test get variable exported by push-to-another-repository
+        run: |
+          echo $DESTINATION_CLONED_DIRECTORY
+          echo "VITE_NAVER_CLIENT_ID = ${{ secrets.VITE_NAVER_CLIENT_ID }}" >> .env
+          echo "VITE_NAVER_CLIENT_SECRET: ${{ secrets.VITE_NAVER_CLIENT_SECRET }}" >> .env

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,8 +22,6 @@ jobs:
         uses: cpina/github-action-push-to-another-repository@main
         env:
           API_TOKEN_GITHUB: ${{ secrets.AUTO_ACTIONS }}
-          VITE_NAVER_CLIENT_ID: ${{ secrets.VITE_NAVER_CLIENT_ID }}
-          VITE_NAVER_CLIENT_SECRET: ${{ secrets.VITE_NAVER_CLIENT_SECRET }}
         with:
           source-directory: 'output'
           destination-github-username: 'karpitony'
@@ -33,7 +31,4 @@ jobs:
           target-branch: main
 
       - name: Test get variable exported by push-to-another-repository
-        run: |
-          echo $DESTINATION_CLONED_DIRECTORY
-          echo "VITE_NAVER_CLIENT_ID = ${{ secrets.VITE_NAVER_CLIENT_ID }}" >> .env
-          echo "VITE_NAVER_CLIENT_SECRET: ${{ secrets.VITE_NAVER_CLIENT_SECRET }}" >> .env
+        run: echo $DESTINATION_CLONED_DIRECTORY

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hookform/resolvers": "^3.9.0",
+        "axios": "^1.7.7",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.0",
@@ -1601,6 +1602,23 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1740,6 +1758,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -1816,6 +1846,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -2202,6 +2241,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
@@ -2217,6 +2276,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fsevents": {
@@ -2644,6 +2717,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -3091,6 +3185,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
       "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
     "node_modules/punycode": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
+    "axios": "^1.7.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.0",

--- a/src/Routers.tsx
+++ b/src/Routers.tsx
@@ -4,6 +4,7 @@ import MainPage from './pages/MainPage.tsx'
 import MyPage from './pages/MyPage.tsx'
 import Login from './pages/Login.tsx'
 import Register from './pages/Register.tsx'
+import Book from './pages/Book.tsx'
 
 export default function Routers() {
   const router = createBrowserRouter([
@@ -13,6 +14,7 @@ export default function Routers() {
       children: [
         { path: '/', element: <MainPage /> },
         { path: '/mypage', element: <MyPage /> },
+        { path: '/book/:bookSlug', element: <Book /> },
         { path: '/login', element: <Login /> },
         { path: '/register', element: <Register /> },
       ],

--- a/src/components/MainPage/CurrentlyTrendingBook.tsx
+++ b/src/components/MainPage/CurrentlyTrendingBook.tsx
@@ -1,51 +1,63 @@
-import BookCardComponent from "../common/BookCardComponent"
-import cn from '../../libs/cn.ts';
+import { useNavigate } from 'react-router-dom'
+import BookCardComponent from '../common/BookCardComponent'
+import cn from '../../libs/cn.ts'
 
 export default function CurrentlyTrendingBook() {
+  const navigate = useNavigate()
+
   // 레이아웃을 위한 임시 데이터
   const tempData = {
     bookList: [
       {
         title: 'Doit! 점프 투 파이썬',
-        imageUrl: 'https://image9.coupangcdn.com/image/vendor_inventory/9ade/a02d54da37050318e16a716ef452616fa0d747061b44b77602408184a384.jpg'
+        imageUrl:
+          'https://image9.coupangcdn.com/image/vendor_inventory/9ade/a02d54da37050318e16a716ef452616fa0d747061b44b77602408184a384.jpg',
       },
       {
         title: '실전 스벨트 & 스벨트킷 입문',
-        imageUrl: 'https://image.yes24.com/YES24ViewerDatas/Z1260_LT/A12594/B125932/125931860_L/15zjwcxrq2qdmcdx01.jpg'
+        imageUrl:
+          'https://image.yes24.com/YES24ViewerDatas/Z1260_LT/A12594/B125932/125931860_L/15zjwcxrq2qdmcdx01.jpg',
       },
       {
         title: '누가 내 머리에 똥쌌어?',
-        imageUrl: 'https://image.yes24.com/YES24ViewerDatas/Z1_LT/A1/B2/1315_L/z35llww4yi7bw722%EB%88%84%EA%B0%80.jpg'
+        imageUrl:
+          'https://image.yes24.com/YES24ViewerDatas/Z1_LT/A1/B2/1315_L/z35llww4yi7bw722%EB%88%84%EA%B0%80.jpg',
       },
       {
         title: '구름빵',
-        imageUrl: 'https://image.yes24.com/goods/1472361/XL'
+        imageUrl: 'https://image.yes24.com/goods/1472361/XL',
       },
-    ]
+    ],
+  }
+
+  const handleBookClick = (title: string) => {
+    const bookSlug = title.toLowerCase().replace(/\s+/g, '-')
+    navigate(`/book/${bookSlug}`)
   }
 
   return (
     <>
-      <h2 
+      <h2
         className={cn(
-          "text-xl md:text-2xl lg:text-4xl font-semibold",
-          "mb-3 md:mb-6 text-center p-4 md:p-8 xl:p-12"
+          'text-xl md:text-2xl lg:text-4xl font-semibold',
+          'mb-3 md:mb-6 text-center p-4 md:p-8 xl:p-12'
         )}
       >
-        지금 독자들이 <span className="text-[#EC6B53]">가장 많이 이야기하는 책</span>
+        지금 독자들이{' '}
+        <span className="text-[#EC6B53]">가장 많이 이야기하는 책</span>
       </h2>
       <div className="flex justify-center">
         <div className="grid grid-cols-3 xl:grid-cols-4 gap-4 max-w-5xl mx-auto px-4">
-          
           {tempData.bookList.map((book, index) => (
-            <BookCardComponent 
-              key={index} 
-              title={book.title} 
+            <BookCardComponent
+              key={index}
+              title={book.title}
               imageUrl={book.imageUrl}
+              onClick={() => handleBookClick(book.title)}
             />
           ))}
         </div>
       </div>
     </>
-  );
+  )
 }

--- a/src/components/MainPage/CurrentlyTrendingBook.tsx
+++ b/src/components/MainPage/CurrentlyTrendingBook.tsx
@@ -9,29 +9,33 @@ export default function CurrentlyTrendingBook() {
   const tempData = {
     bookList: [
       {
+        isbn: 9791163034735,
         title: 'Doit! 점프 투 파이썬',
         imageUrl:
           'https://image9.coupangcdn.com/image/vendor_inventory/9ade/a02d54da37050318e16a716ef452616fa0d747061b44b77602408184a384.jpg',
       },
       {
+        isbn: 9791193926161,
         title: '실전 스벨트 & 스벨트킷 입문',
         imageUrl:
           'https://image.yes24.com/YES24ViewerDatas/Z1260_LT/A12594/B125932/125931860_L/15zjwcxrq2qdmcdx01.jpg',
       },
       {
+        isbn: 9788971968413,
         title: '누가 내 머리에 똥쌌어?',
         imageUrl:
           'https://image.yes24.com/YES24ViewerDatas/Z1_LT/A1/B2/1315_L/z35llww4yi7bw722%EB%88%84%EA%B0%80.jpg',
       },
       {
+        isbn: 9791170283836,
         title: '구름빵',
         imageUrl: 'https://image.yes24.com/goods/1472361/XL',
       },
     ],
   }
 
-  const handleBookClick = (title: string) => {
-    const bookSlug = title.toLowerCase().replace(/\s+/g, '-')
+  const handleBookClick = (isbn: number) => {
+    const bookSlug = isbn.toString()
     navigate(`/book/${bookSlug}`)
   }
 
@@ -53,7 +57,7 @@ export default function CurrentlyTrendingBook() {
               key={index}
               title={book.title}
               imageUrl={book.imageUrl}
-              onClick={() => handleBookClick(book.title)}
+              onClick={() => handleBookClick(book.isbn)}
             />
           ))}
         </div>

--- a/src/components/common/BookCardComponent.tsx
+++ b/src/components/common/BookCardComponent.tsx
@@ -1,26 +1,32 @@
 import cn from '../../libs/cn'
 
 interface BookCardComponentProps {
-  title: string;
-  imageUrl: string;
+  title: string
+  imageUrl: string
+  onClick?: () => void
 }
 
-export default function BookCardComponent({ title, imageUrl }: BookCardComponentProps) {
+export default function BookCardComponent({
+  title,
+  imageUrl,
+  onClick,
+}: BookCardComponentProps) {
   return (
-    <div className='flex flex-col items-center justify-center'>
-      <img 
+    <div
+      className="flex flex-col items-center justify-center"
+      onClick={onClick}
+    >
+      <img
         src={imageUrl}
-        alt="book" 
+        alt="book"
         className={cn(
-          "w-32 h-40 md:w-48 md:h-60 lg:w-60 lg:h-80 object-cover mb-4 rounded-lg shadow-lg",
-          "transform transition duration-300 ease-in-out",
+          'w-32 h-40 md:w-48 md:h-60 lg:w-60 lg:h-80 object-cover mb-4 rounded-lg shadow-lg',
+          'transform transition duration-300 ease-in-out',
           // 호버 시 크기, 그림자, 위치 변경
-          "hover:scale-105 hover:shadow-2xl hover:translate-y-2" 
+          'hover:scale-105 hover:shadow-2xl hover:translate-y-2'
         )}
       />
-      <h3 className="text-center text-sm md:text-base lg:text-lg">
-        { title }
-      </h3>
+      <h3 className="text-center text-sm md:text-base lg:text-lg">{title}</h3>
     </div>
   )
 }

--- a/src/config/BookClient.ts
+++ b/src/config/BookClient.ts
@@ -1,0 +1,9 @@
+export const NAVER_API_HEADERS = {
+  'X-Naver-Client-Id': import.meta.env.VITE_NAVER_CLIENT_ID,
+  'X-Naver-Client-Secret': import.meta.env.VITE_NAVER_CLIENT_SECRET,
+}
+
+const BOOK_SEARCH_ENDPOINT = '/v1/search/book.json'
+
+export const getBookSearchUrl = (query: string) =>
+  `${BOOK_SEARCH_ENDPOINT}?query=${query}`

--- a/src/hooks/UseBook.tsx
+++ b/src/hooks/UseBook.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { fetchBookData } from '../services/BookService'
+import { BookData } from '../model/BookData'
+
+export const useBook = () => {
+  const { bookSlug } = useParams()
+  const [bookData, setBookData] = useState<BookData | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (bookSlug) {
+      const getBookData = async () => {
+        try {
+          const data = await fetchBookData(bookSlug)
+          setBookData(data)
+        } catch (err) {
+          setError(
+            err instanceof Error
+              ? err.message
+              : '알 수 없는 오류가 발생했습니다.'
+          )
+        }
+      }
+
+      getBookData()
+    }
+  }, [bookSlug])
+
+  return { bookData, error }
+}

--- a/src/model/BookData.tsx
+++ b/src/model/BookData.tsx
@@ -1,0 +1,11 @@
+export interface BookData {
+  title: string
+  link: string
+  image: string
+  author: string
+  discount: string
+  publisher: string
+  pubdate: string
+  isbn: string
+  description: string
+}

--- a/src/pages/Book.tsx
+++ b/src/pages/Book.tsx
@@ -1,12 +1,32 @@
-import { useParams } from 'react-router-dom'
+import { useBook } from '../hooks/UseBook'
 
 export default function Book() {
-  const { bookSlug } = useParams()
+  const { bookData, error } = useBook()
+
+  if (error) {
+    return <p>Error: {error}</p>
+  }
 
   return (
     <div>
       <h1>Book Detail Page</h1>
-      <p>Book Slug: {bookSlug}</p>
+      {bookData ? (
+        <div>
+          <p>Title: {bookData.title}</p>
+          <p>Author: {bookData.author}</p>
+          <p>Publisher: {bookData.publisher}</p>
+          <p>Publication Date: {bookData.pubdate}</p>
+          <p>ISBN: {bookData.isbn}</p>
+          <p>Price: {bookData.discount} 원</p>
+          <p>Description: {bookData.description}</p>
+          <a href={bookData.link} target="_blank" rel="noopener noreferrer">
+            자세히 보기
+          </a>
+          <img src={bookData.image} alt={bookData.title} />
+        </div>
+      ) : (
+        <p>No book data available.</p>
+      )}
     </div>
   )
 }

--- a/src/pages/Book.tsx
+++ b/src/pages/Book.tsx
@@ -1,0 +1,12 @@
+import { useParams } from 'react-router-dom'
+
+export default function Book() {
+  const { bookSlug } = useParams()
+
+  return (
+    <div>
+      <h1>Book Detail Page</h1>
+      <p>Book Slug: {bookSlug}</p>
+    </div>
+  )
+}

--- a/src/services/BookService.ts
+++ b/src/services/BookService.ts
@@ -1,0 +1,34 @@
+import axios from 'axios'
+import { NAVER_API_HEADERS, getBookSearchUrl } from '../config/BookClient'
+import { BookData } from '../model/BookData'
+
+const ERROR_MESSAGES = {
+  NOT_FOUND: '책 데이터를 찾을 수 없습니다.',
+  API_REQUEST_FAILED: '네이버 API 요청 실패',
+  UNKNOWN_ERROR: '알 수 없는 오류가 발생했습니다.',
+}
+
+export const fetchBookData = async (
+  bookSlug: string
+): Promise<BookData | null> => {
+  try {
+    const response = await axios.get(getBookSearchUrl(bookSlug), {
+      headers: NAVER_API_HEADERS,
+    })
+
+    const data = response.data
+    if (data.items && data.items.length > 0) {
+      return data.items[0]
+    } else {
+      throw new Error(ERROR_MESSAGES.NOT_FOUND)
+    }
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      throw new Error(
+        error.response.data.message || ERROR_MESSAGES.API_REQUEST_FAILED
+      )
+    } else {
+      throw new Error(ERROR_MESSAGES.UNKNOWN_ERROR)
+    }
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react-swc';
-import tailwindcss from 'tailwindcss';
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react-swc'
+import tailwindcss from 'tailwindcss'
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -10,4 +10,15 @@ export default defineConfig({
       plugins: [tailwindcss()],
     },
   },
-});
+  server: {
+    proxy: {
+      '/v1': {
+        target: 'https://openapi.naver.com',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+        secure: false,
+        ws: true,
+      },
+    },
+  },
+})


### PR DESCRIPTION
## #️⃣연관된 이슈

> #18 

## 📝작업 내용

> CurrentlyTrendingBook 컴포넌트에 OnClick 메소드와 해당 책의 isbn을 통해 책의 상세 페이지로 이동하도록 해두었습니다. (isbn은 임시로 하드코딩하여 넣어두었습니다.) 
> `BookClient`는 책 관련 api Client를 작성하였고, `BookData`에 응답 타입을 정의해 두었고, `BookService`에서 api 호출을 담당합니다.
> 포스트맨에서는 통신이 잘 되었으나, 브라우저에서 cors 문제가 발생하여 proxy를 설정해 두었습니다.

### 스크린샷

> ![image](https://github.com/user-attachments/assets/f0c6036a-5d81-47e5-9300-b343c2273c2c)

## 💬리뷰 요구사항

> `axios` 패키지가 추가되었습니다.
> api 값 확인용으로 코딩하였습니다. 이번 pr 이후 UI 작업하겠습니다.
> api key 관련해서 배포 워크플로우 코드를 수정하였습니다. 이 부분 확인 한 번 해주시면 감사하겠습니다!
