### PR TITLE
[FEAT] - 메인 페이지 검색과 네이버 도서 api 연결

### DIFF
--- a/src/components/MainPage/CurrentlyTrendingBook.tsx
+++ b/src/components/MainPage/CurrentlyTrendingBook.tsx
@@ -9,32 +9,32 @@ export default function CurrentlyTrendingBook() {
   const tempData = {
     bookList: [
       {
-        isbn: 9791163034735,
+        isbn: '9791163034735',
         title: 'Doit! 점프 투 파이썬',
         imageUrl:
           'https://image9.coupangcdn.com/image/vendor_inventory/9ade/a02d54da37050318e16a716ef452616fa0d747061b44b77602408184a384.jpg',
       },
       {
-        isbn: 9791193926161,
+        isbn: '9791193926161',
         title: '실전 스벨트 & 스벨트킷 입문',
         imageUrl:
           'https://image.yes24.com/YES24ViewerDatas/Z1260_LT/A12594/B125932/125931860_L/15zjwcxrq2qdmcdx01.jpg',
       },
       {
-        isbn: 9788971968413,
+        isbn: '9788971968413',
         title: '누가 내 머리에 똥쌌어?',
         imageUrl:
           'https://image.yes24.com/YES24ViewerDatas/Z1_LT/A1/B2/1315_L/z35llww4yi7bw722%EB%88%84%EA%B0%80.jpg',
       },
       {
-        isbn: 9791170283836,
+        isbn: '9791170283836',
         title: '구름빵',
         imageUrl: 'https://image.yes24.com/goods/1472361/XL',
       },
     ],
   }
 
-  const handleBookClick = (isbn: number) => {
+  const handleBookClick = (isbn: string) => {
     const bookSlug = isbn.toString()
     navigate(`/book/${bookSlug}`)
   }

--- a/src/components/MainPage/MainPageContext.tsx
+++ b/src/components/MainPage/MainPageContext.tsx
@@ -1,0 +1,29 @@
+import cn from '../../libs/cn';
+
+export default function MainPageContext() {
+  return (
+    <div
+    className={cn(
+      'relative w-full flex-col justify-center text-center',
+      'flex flex-col items-center gap-3 md:gap-6',
+      'w-fit font-rockwell font-normal'
+    )}
+  >
+    <h1 
+      className={cn(
+        "w-fit text-4xl md:text-6xl xl:text-8xl text-[#2B5877]",
+        "mt-14 md:mt-20 xl:mt-32"
+      )}
+      style={{ letterSpacing: '0.1em' }}
+    >
+      BookLog
+    </h1>
+    <h2 className={cn(
+      "w-fit text-base md:text-2xl xl:text-4xl text-[#918F8F]",
+      'mb-6 md:mb-0'
+    )}>
+      join our community and share your book reviews.
+    </h2>
+  </div>
+  )
+};

--- a/src/components/MainPage/SearchBar.tsx
+++ b/src/components/MainPage/SearchBar.tsx
@@ -1,26 +1,23 @@
 import { useState, useRef } from 'react';
-import MagnifyingGlass from'../../assets/icons/MagnifyingGlass.svg';
+import MagnifyingGlass from '../../assets/icons/MagnifyingGlass.svg';
 import cn from '../../libs/cn.ts';
 
 interface SearchBarProps {
+  searchText: string;
   onSearch: (searchText: string) => void;
 }
 
-export default function SearchBar({ onSearch }: SearchBarProps) {
-  const [searchText, setSearchText] = useState('');
+export default function SearchBar({ onSearch, searchText }: SearchBarProps) {
+  const [localSearchText, setLocalSearchText] = useState(searchText);
   const [placeholder, setPlaceholder] = useState('궁금한 책 제목이나 저자를 검색해보세요!');
   const inputRef = useRef<HTMLInputElement | null>(null);
 
-  const handleButtonClick = () => {
-    const enterKeyDownEvent = new KeyboardEvent('keydown', {
-      key: 'Enter',
-      code: 'Enter',
-      bubbles: true,
-    });
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setLocalSearchText(e.target.value); // 입력한 텍스트 업데이트
+  };
 
-    if (inputRef.current) {
-      inputRef.current.dispatchEvent(enterKeyDownEvent);
-    }
+  const handleButtonClick = () => {
+    onSearch(localSearchText); // 검색어를 전달
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -29,8 +26,7 @@ export default function SearchBar({ onSearch }: SearchBarProps) {
     }
     e.preventDefault();
     
-    // 검색어를 부모 컴포넌트에 전달
-    onSearch(searchText);
+    handleButtonClick(); // 엔터키 눌렀을 때 검색 버튼 클릭 동작 수행
   };
 
   return (
@@ -46,10 +42,10 @@ export default function SearchBar({ onSearch }: SearchBarProps) {
           placeholder={placeholder}
           onFocus={() => setPlaceholder('')}
           onBlur={() => setPlaceholder('궁금한 책 제목이나 저자를 검색해보세요!')}
-          value={searchText}
+          value={localSearchText}
           ref={inputRef}
           onKeyDown={handleKeyDown}
-          onChange={(e) => setSearchText(e.target.value)}
+          onChange={handleInputChange}
           className={cn(
             'w-full p-2 text-center', // 반응형 너비
             'text-base md:text-xl xl:text-3xl focus:outline-none'

--- a/src/components/MainPage/SearchResult.tsx
+++ b/src/components/MainPage/SearchResult.tsx
@@ -1,7 +1,6 @@
 import { useSearchBookByName } from '../../hooks/UseSearchBookbyName';
 import { BookData } from '../../model/BookData';
 import BookCardComponent from '../common/BookCardComponent';
-import cn from '../../libs/cn.ts';
 
 interface SearchResultProps {
   searchTerm: string;
@@ -17,19 +16,22 @@ export default function SearchResult({ searchTerm }: SearchResultProps) {
 
   return (
     <div className="p-4">
-      <h1
-        className={cn(
-          'text-2xl md:text-3xl lg:text-4xl font-semibold text-center',
-          'mb-6 text-[#EC6B53]'
-        )}
-      >
-        검색 결과
-      </h1>
       {loading && <p className="text-center">Loading...</p>}
       {error && <p className="text-center text-red-500">{error}</p>}
+
+      {/* 검색 결과가 없을 때 */}
       {!loading && !error && books.length === 0 && (
         <p className="text-center">검색 결과가 없습니다.</p>
       )}
+
+      {/* 검색 결과가 있을 때만 헤더 표시 */}
+      {!loading && !error && books.length > 0 && (
+        <div className="text-left max-w-5xl mx-auto px-4">
+          <h2 className='text-xl md:text-3xl font-semibold pr-2 md:pr-4 inline'>{searchTerm}</h2>
+          <p className='text-lg md:text-2xl inline'>검색 결과 <span className='pl-1 text-[#EC6B53]'>{books.length}건</span></p>
+        </div>
+      )}
+
       <div className="flex justify-center">
         <div className="grid grid-cols-3 xl:grid-cols-4 gap-4 max-w-5xl mx-auto px-4">
           {!loading && !error && books.map((book: BookData, index: number) => (

--- a/src/components/MainPage/SearchResult.tsx
+++ b/src/components/MainPage/SearchResult.tsx
@@ -1,33 +1,47 @@
-import { useSearchBookByName } from '../../hooks/UseSearchBookbyName'
-import { BookData } from '../../model/BookData'
+import { useSearchBookByName } from '../../hooks/UseSearchBookbyName';
+import { BookData } from '../../model/BookData';
+import BookCardComponent from '../common/BookCardComponent';
+import cn from '../../libs/cn.ts';
 
 interface SearchResultProps {
-  searchTerm: string
+  searchTerm: string;
 }
 
 export default function SearchResult({ searchTerm }: SearchResultProps) {
-  const { books, error, loading } = useSearchBookByName(searchTerm)
+  const { books, error, loading } = useSearchBookByName(searchTerm);
+
+  const handleBookClick = (isbn: string) => {
+    const bookSlug = isbn.toString();
+    window.open(`/book/${bookSlug}`, '_blank'); // 새 탭에서 열기
+  };
 
   return (
-    <div>
-      <h1>Search Result Page</h1>
-      {loading && <p>Loading...</p>}
-      {error && <p>{error}</p>}
-      {!loading && !error && books.length === 0 && <p>No results found.</p>}
-      <ul>
-        {books.map((book: BookData, index: number) => (
-          <li key={index}>
-            <h2>{book.title}</h2>
-            <p>{book.author}</p>
-            <img src={book.image} alt={book.title} />
-            <p>{book.publisher}</p>
-            <p>{book.pubdate}</p>
-            <a href={book.link} target="_blank" rel="noopener noreferrer">
-              More Info
-            </a>
-          </li>
-        ))}
-      </ul>
+    <div className="p-4">
+      <h1
+        className={cn(
+          'text-2xl md:text-3xl lg:text-4xl font-semibold text-center',
+          'mb-6 text-[#EC6B53]'
+        )}
+      >
+        검색 결과
+      </h1>
+      {loading && <p className="text-center">Loading...</p>}
+      {error && <p className="text-center text-red-500">{error}</p>}
+      {!loading && !error && books.length === 0 && (
+        <p className="text-center">검색 결과가 없습니다.</p>
+      )}
+      <div className="flex justify-center">
+        <div className="grid grid-cols-3 xl:grid-cols-4 gap-4 max-w-5xl mx-auto px-4">
+          {!loading && !error && books.map((book: BookData, index: number) => (
+            <BookCardComponent
+              key={index}
+              title={book.title}
+              imageUrl={book.image}
+              onClick={() => handleBookClick(book.isbn)}
+            />
+          ))}
+        </div>
+      </div>
     </div>
-  )
+  );
 }

--- a/src/components/MainPage/SearchResult.tsx
+++ b/src/components/MainPage/SearchResult.tsx
@@ -1,0 +1,33 @@
+import { useSearchBookByName } from '../../hooks/UseSearchBookbyName'
+import { BookData } from '../../model/BookData'
+
+interface SearchResultProps {
+  searchTerm: string
+}
+
+export default function SearchResult({ searchTerm }: SearchResultProps) {
+  const { books, error, loading } = useSearchBookByName(searchTerm)
+
+  return (
+    <div>
+      <h1>Search Result Page</h1>
+      {loading && <p>Loading...</p>}
+      {error && <p>{error}</p>}
+      {!loading && !error && books.length === 0 && <p>No results found.</p>}
+      <ul>
+        {books.map((book: BookData, index: number) => (
+          <li key={index}>
+            <h2>{book.title}</h2>
+            <p>{book.author}</p>
+            <img src={book.image} alt={book.title} />
+            <p>{book.publisher}</p>
+            <p>{book.pubdate}</p>
+            <a href={book.link} target="_blank" rel="noopener noreferrer">
+              More Info
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/components/common/BookCardComponent.tsx
+++ b/src/components/common/BookCardComponent.tsx
@@ -13,7 +13,7 @@ export default function BookCardComponent({
 }: BookCardComponentProps) {
   return (
     <div
-      className="flex flex-col items-center justify-center"
+      className="flex flex-col items-center"
       onClick={onClick}
     >
       <img

--- a/src/config/BookClient.ts
+++ b/src/config/BookClient.ts
@@ -5,5 +5,12 @@ export const NAVER_API_HEADERS = {
 
 const BOOK_SEARCH_ENDPOINT = '/v1/search/book.json'
 
-export const getBookSearchUrl = (query: string) =>
-  `${BOOK_SEARCH_ENDPOINT}?query=${query}`
+export const getBookSearchUrl = (query: string, display?: number) => {
+  let url = `${BOOK_SEARCH_ENDPOINT}?query=${query}`;
+  
+  if (display !== undefined) {
+    url += `&display=${display}`;
+  }
+
+  return url;
+}

--- a/src/hooks/UseSearchBookbyName.tsx
+++ b/src/hooks/UseSearchBookbyName.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+import { NAVER_API_HEADERS, getBookSearchUrl } from '../config/BookClient'
+import { BookData } from '../model/BookData'
+
+const ERROR_MESSAGES = {
+  NOT_FOUND: '책 데이터를 찾을 수 없습니다.',
+  API_REQUEST_FAILED: '네이버 API 요청 실패',
+  UNKNOWN_ERROR: '알 수 없는 오류가 발생했습니다.',
+}
+
+export const useSearchBookByName = (searchTerm: string) => {
+  const [books, setBooks] = useState<BookData[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState<boolean>(false)
+
+  useEffect(() => {
+    if (searchTerm) {
+      const fetchBooks = async () => {
+        setLoading(true)
+        setError(null)
+        try {
+          const response = await axios.get(getBookSearchUrl(searchTerm), {
+            headers: NAVER_API_HEADERS,
+          })
+
+          const data = response.data
+          if (data.items && data.items.length > 0) {
+            setBooks(data.items)
+          } else {
+            setBooks([])
+            throw new Error(ERROR_MESSAGES.NOT_FOUND)
+          }
+        } catch (err) {
+          setError(
+            axios.isAxiosError(err) && err.response
+              ? err.response.data.message || ERROR_MESSAGES.API_REQUEST_FAILED
+              : ERROR_MESSAGES.UNKNOWN_ERROR
+          )
+        } finally {
+          setLoading(false)
+        }
+      }
+
+      fetchBooks()
+    } else {
+      setBooks([])
+    }
+  }, [searchTerm])
+
+  return { books, error, loading }
+}

--- a/src/hooks/UseSearchBookbyName.tsx
+++ b/src/hooks/UseSearchBookbyName.tsx
@@ -20,7 +20,7 @@ export const useSearchBookByName = (searchTerm: string) => {
         setLoading(true)
         setError(null)
         try {
-          const response = await axios.get(getBookSearchUrl(searchTerm), {
+          const response = await axios.get(getBookSearchUrl(searchTerm, 100), {
             headers: NAVER_API_HEADERS,
           })
 

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -2,13 +2,15 @@ import { useState } from 'react';
 import MainPageContext from '../components/MainPage/MainPageContext.tsx';
 import SearchBar from '../components/MainPage/SearchBar.tsx';
 import CurrentlyTrendingBook from '../components/MainPage/CurrentlyTrendingBook.tsx';
+import SearchResult from '../components/MainPage/SearchResult.tsx';
 
 export default function MainPage() {
   const [isSearch, setIsSearch] = useState(false);
+  const [searchText, setSearchText] = useState('');
 
   const handleSearch = (searchText: string) => {
-    alert(`검색 결과 페이지로 이동합니다. 검색어: ${searchText}`);
     setIsSearch(true);
+    setSearchText(searchText);
   };
 
   return (
@@ -16,10 +18,13 @@ export default function MainPage() {
       <MainPageContext />
 
       {/* Search Bar */}
-      <SearchBar onSearch={handleSearch} />
+      <SearchBar 
+        onSearch={handleSearch} 
+        searchText={searchText}
+      />
     
       <div>
-        {!isSearch && <CurrentlyTrendingBook />}
+        {isSearch ? <SearchResult searchTerm={searchText} /> : <CurrentlyTrendingBook/>}
       </div>
     </>
   );

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import cn from '../libs/cn.ts';
+import MainPageContext from '../components/MainPage/MainPageContext.tsx';
 import SearchBar from '../components/MainPage/SearchBar.tsx';
 import CurrentlyTrendingBook from '../components/MainPage/CurrentlyTrendingBook.tsx';
 
@@ -13,29 +13,7 @@ export default function MainPage() {
 
   return (
     <>
-      <div
-        className={cn(
-          'relative w-full flex-col justify-center text-center',
-          'flex flex-col items-center gap-3 md:gap-6',
-          'w-fit font-rockwell font-normal'
-        )}
-      >
-        <h1 
-          className={cn(
-            "w-fit text-4xl md:text-6xl xl:text-8xl text-[#2B5877]",
-            "mt-14 md:mt-20 xl:mt-32"
-          )}
-          style={{ letterSpacing: '0.1em' }}
-        >
-          BookLog
-        </h1>
-        <h2 className={cn(
-          "w-fit text-base md:text-2xl xl:text-4xl text-[#918F8F]",
-          'mb-6 md:mb-0'
-        )}>
-          join our community and share your book reviews.
-        </h2>
-      </div>
+      <MainPageContext />
 
       {/* Search Bar */}
       <SearchBar onSearch={handleSearch} />


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #10 

## 📝작업 내용

> - 메인 페이지 검색과 도서 api 연결
> - 도서 검색을 위한 커스텀 훅 만들기
> - 검색 도서 클릭시 / 메인 페이지 추천 도서 클릭시 도서 상세 페이지로 연결
> - 기존 `config/Bookclient.ts`에 display 옵션 추가 (선택 옵션으로 추가)

## 스크린샷

| 모바일 | 데스크톱 |
|:---:|:---:|
| <img width="449" alt="스크린샷 2024-10-10 오후 12 27 02" src="https://github.com/user-attachments/assets/4b9cf666-fb90-4fea-97fe-9d5a5ebfc199"> | <img width="1383" alt="스크린샷 2024-10-10 오후 12 27 21" src="https://github.com/user-attachments/assets/3e420c3b-2c80-4848-babd-ee751b7729b6"> |

## 💬리뷰 요구사항

> - 커스텀 훅을 처음 만들어봐서 잘 만들었는지 피드백 받고 싶습니다! 25a3933228b298529c4addd23e47766d96ca17b5
> - `config/Bookclient.ts`를 조금 수정했는데 문제가 생기지 않을까 확인한번 부탁드립니다. 02a2933952ef7350975d6d5d08d9b7943a6706e9