### PR TITLE
[FEAT] - 에디터 페이지와 검색 api 연결하기

### DIFF
--- a/src/assets/icons/Back.svg
+++ b/src/assets/icons/Back.svg
@@ -1,6 +1,6 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <g clip-path="url(#clip0_2242_1934)">
-<path d="M17.0977 24L5.09766 12L17.0977 0L18.9277 1.8501L8.77776 12L18.9277 22.1499L17.0977 24Z" fill="#4e4d4d"/>
+<path d="M17.0977 24L5.09766 12L17.0977 0L18.9277 1.8501L8.77776 12L18.9277 22.1499L17.0977 24Z" fill="white"/>
 </g>
 <defs>
 <clipPath id="clip0_2242_1934">

--- a/src/components/Editor/BookReportHeader.tsx
+++ b/src/components/Editor/BookReportHeader.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import DefaultThubnail from '../../assets/images/DefaultThubnail.png';
 import cn from '../../libs/cn';
 import SearchBar from './BookReportHeader/SearchBar';
@@ -9,6 +9,7 @@ export default function BookReportHeaderEditor() {
   const [thumbnail, setThumbnail] = useState<string>('');
   const [readBookTitle, setReadBookTitle] = useState<string>('');
   const [searchText, setSearchText] = useState<string>(''); // 검색어 상태 추가
+  const [bookIsbn, setBookIsbn] = useState<string>(''); // 책의 ISBN 상태 추가
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -28,6 +29,12 @@ export default function BookReportHeaderEditor() {
     setReadBookTitle(result); 
     setSearchText(''); 
   };
+
+  useEffect(() => {
+    if (bookIsbn) {
+      console.log('ISBN:', bookIsbn);
+    }
+  }, [bookIsbn]);
 
   return (
     <div className={cn(
@@ -95,6 +102,7 @@ export default function BookReportHeaderEditor() {
         <SearchResults 
           searchText={searchText}
           onResultClick={handleResultClick}
+          setBookIsbn={setBookIsbn}
         />
       </div>
     </div>

--- a/src/components/Editor/BookReportHeader.tsx
+++ b/src/components/Editor/BookReportHeader.tsx
@@ -1,14 +1,11 @@
 import { useState, useRef, useEffect } from 'react';
 import DefaultThubnail from '../../assets/images/DefaultThubnail.png';
 import cn from '../../libs/cn';
-import SearchBar from './BookReportHeader/SearchBar';
-import SearchResults from './BookReportHeader/SearchResults';
+import Search from './Search';
 
 export default function BookReportHeaderEditor() {
   const [title, setTitle] = useState<string>(''); 
   const [thumbnail, setThumbnail] = useState<string>('');
-  const [readBookTitle, setReadBookTitle] = useState<string>('');
-  const [searchText, setSearchText] = useState<string>(''); // 검색어 상태 추가
   const [bookIsbn, setBookIsbn] = useState<string>(''); // 책의 ISBN 상태 추가
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -19,15 +16,6 @@ export default function BookReportHeaderEditor() {
       const imageUrl = URL.createObjectURL(file);
       setThumbnail(imageUrl); // 이미지 미리보기
     }
-  };
-
-  const handleSearch = (text: string) => {
-    setSearchText(text); 
-  };
-
-  const handleResultClick = (result: string) => {
-    setReadBookTitle(result); 
-    setSearchText(''); 
   };
 
   useEffect(() => {
@@ -90,20 +78,9 @@ export default function BookReportHeaderEditor() {
             />
           </div>
         </div>
-      
-        {/* SearchBar 컴포넌트 */}
-        <SearchBar 
-          readBookTitle={readBookTitle}
-          setReadBookTitle={setReadBookTitle}
-          onSearch={handleSearch}
-        />
 
-        {/* SearchResults 컴포넌트에 검색어 전달 */}
-        <SearchResults 
-          searchText={searchText}
-          onResultClick={handleResultClick}
-          setBookIsbn={setBookIsbn}
-        />
+        <Search setBookIsbn={setBookIsbn}/>
+
       </div>
     </div>
   );

--- a/src/components/Editor/BookReportHeader.tsx
+++ b/src/components/Editor/BookReportHeader.tsx
@@ -1,15 +1,21 @@
-import { useState, useRef, useEffect } from 'react';
+import { useRef, useEffect } from 'react';
 import DefaultThubnail from '../../assets/images/DefaultThubnail.png';
 import cn from '../../libs/cn';
 import Search from './Search';
 
-export default function BookReportHeaderEditor() {
-  const [title, setTitle] = useState<string>(''); 
-  const [thumbnail, setThumbnail] = useState<string>('');
-  const [bookIsbn, setBookIsbn] = useState<string>(''); // 책의 ISBN 상태 추가
+interface BookReportHeaderEditorProps {
+  title: string;
+  setTitle: (value: string) => void;
+  thumbnail: string;
+  setThumbnail: (value: string) => void;
+  bookIsbn: string;
+  setBookIsbn: (value: string) => void;
+}
+
+export default function BookReportHeaderEditor(
+  {title, setTitle, thumbnail, setThumbnail, bookIsbn, setBookIsbn}: BookReportHeaderEditorProps) {
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-
   const handleThumbnailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
@@ -80,7 +86,6 @@ export default function BookReportHeaderEditor() {
         </div>
 
         <Search setBookIsbn={setBookIsbn}/>
-
       </div>
     </div>
   );

--- a/src/components/Editor/BookReportHeader.tsx
+++ b/src/components/Editor/BookReportHeader.tsx
@@ -2,11 +2,13 @@ import { useState, useRef } from 'react';
 import DefaultThubnail from '../../assets/images/DefaultThubnail.png';
 import cn from '../../libs/cn';
 import SearchBar from './BookReportHeader/SearchBar';
+import SearchResults from './BookReportHeader/SearchResults';
 
 export default function BookReportHeaderEditor() {
   const [title, setTitle] = useState<string>(''); 
   const [thumbnail, setThumbnail] = useState<string>('');
   const [readBookTitle, setReadBookTitle] = useState<string>('');
+  const [searchText, setSearchText] = useState<string>(''); // 검색어 상태 추가
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -18,9 +20,13 @@ export default function BookReportHeaderEditor() {
     }
   };
 
-  const handleSearch = (searchText: string) => {
-    console.log('Search Text:', searchText);
-    // 검색어 처리 로직
+  const handleSearch = (text: string) => {
+    setSearchText(text); 
+  };
+
+  const handleResultClick = (result: string) => {
+    setReadBookTitle(result); 
+    setSearchText(''); 
   };
 
   return (
@@ -80,9 +86,15 @@ export default function BookReportHeaderEditor() {
       
         {/* SearchBar 컴포넌트 */}
         <SearchBar 
-          readBookTitle={readBookTitle} // 책 이름을 props로 전달
-          setReadBookTitle={setReadBookTitle} // 책 이름 업데이트 함수 전달
-          onSearch={handleSearch} // 검색 함수 전달
+          readBookTitle={readBookTitle}
+          setReadBookTitle={setReadBookTitle}
+          onSearch={handleSearch}
+        />
+
+        {/* SearchResults 컴포넌트에 검색어 전달 */}
+        <SearchResults 
+          searchText={searchText}
+          onResultClick={handleResultClick}
         />
       </div>
     </div>

--- a/src/components/Editor/BookReportHeader.tsx
+++ b/src/components/Editor/BookReportHeader.tsx
@@ -16,12 +16,17 @@ export default function BookReportHeaderEditor(
   {title, setTitle, thumbnail, setThumbnail, bookIsbn, setBookIsbn}: BookReportHeaderEditorProps) {
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  
   const handleThumbnailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
       const imageUrl = URL.createObjectURL(file);
       setThumbnail(imageUrl); // 이미지 미리보기
     }
+  };
+
+  const handleThumbnailClick = () => {
+    fileInputRef.current?.click();
   };
 
   useEffect(() => {
@@ -80,6 +85,7 @@ export default function BookReportHeaderEditor(
             <img
               src={thumbnail || DefaultThubnail} 
               alt="썸네일" 
+              onClick={handleThumbnailClick}
               className="w-14 h-14 rounded-lg" 
             />
           </div>

--- a/src/components/Editor/BookReportHeader/SearchResults.tsx
+++ b/src/components/Editor/BookReportHeader/SearchResults.tsx
@@ -5,24 +5,21 @@ import BookCardComponent from '../../common/BookCardComponent';
 interface SearchResultsProps {
   searchText: string;
   onResultClick: (result: string) => void;
+  setBookIsbn: (value: string) => void;
 }
 
-export default function SearchResults({ searchText, onResultClick }: SearchResultsProps) {
+export default function SearchResults({ searchText, onResultClick, setBookIsbn }: SearchResultsProps) {
   const { books, error, loading } = useSearchBookByName(searchText);
 
-  const handleBookClick = (bookTitle: string) => {
-    onResultClick(bookTitle);
+  const handleBookClick = (book:any) => {
+    onResultClick(book.title);
+    setBookIsbn(book.isbn);
   };
 
   return (
     <div className="p-4 relative">
       {loading && <p className="text-center">Loading...</p>}
       {error && <p className="text-center text-red-500">{error}</p>}
-
-      {/* 검색 결과가 없을 때 */}
-      {!loading && !error && books.length === 0 && (
-        <p className="text-center">검색 결과가 없습니다.</p>
-      )}
 
       {/* 검색 결과 목록 */}
       <div
@@ -35,7 +32,7 @@ export default function SearchResults({ searchText, onResultClick }: SearchResul
               key={index}
               title={book.title}
               imageUrl={book.image}
-              onClick={() => handleBookClick(book.title)}
+              onClick={() => handleBookClick(book)}
             />
           ))}
         </div>

--- a/src/components/Editor/BookReportHeader/SearchResults.tsx
+++ b/src/components/Editor/BookReportHeader/SearchResults.tsx
@@ -1,0 +1,45 @@
+import { useSearchBookByName } from '../../../hooks/UseSearchBookbyName';
+import { BookData } from '../../../model/BookData';
+import BookCardComponent from '../../common/BookCardComponent';
+
+interface SearchResultsProps {
+  searchText: string;
+  onResultClick: (result: string) => void;
+}
+
+export default function SearchResults({ searchText, onResultClick }: SearchResultsProps) {
+  const { books, error, loading } = useSearchBookByName(searchText);
+
+  const handleBookClick = (bookTitle: string) => {
+    onResultClick(bookTitle);
+  };
+
+  return (
+    <div className="p-4 relative">
+      {loading && <p className="text-center">Loading...</p>}
+      {error && <p className="text-center text-red-500">{error}</p>}
+
+      {/* 검색 결과가 없을 때 */}
+      {!loading && !error && books.length === 0 && (
+        <p className="text-center">검색 결과가 없습니다.</p>
+      )}
+
+      {/* 검색 결과 목록 */}
+      <div
+        className="absolute top-0 left-0 w-full bg-white shadow-lg rounded-lg z-50 mt-2"
+        style={{ zIndex: 1 }} 
+      >
+        <div className="grid grid-cols-3 xl:grid-cols-4 gap-4 max-w-4xl mx-auto px-4">
+          {!loading && !error && books.map((book: BookData, index: number) => (
+            <BookCardComponent
+              key={index}
+              title={book.title}
+              imageUrl={book.image}
+              onClick={() => handleBookClick(book.title)}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Editor/Footer.tsx
+++ b/src/components/Editor/Footer.tsx
@@ -1,4 +1,5 @@
 import cn from '../../libs/cn';
+import Back from '../../assets/icons/Back.svg';
 
 interface FooterProps {
   isPostOk: boolean;
@@ -17,8 +18,21 @@ export default function Footer({isPostOk, onPost, onCancel}: FooterProps) {
   };
 
   return (
-    <footer className="bg-[#2B5877] flex justify-between">
-      <button onClick={onCancel}>
+    <footer 
+      className={cn(
+        "bg-[#2B5877] flex justify-between p-2 md:p-5 w-full",
+        "fixed bottom-0 left-0 h-[60px] md:h-[80px]"
+      )}
+    >
+      <button 
+        onClick={onCancel}
+        className='text-white font-semibold flex items-center'
+      >
+        <img 
+          src={Back} 
+          alt="Back" 
+          className="w-4 md:w-6 h-4 md:h-6 inline mr-2"
+        />
         작성취소
       </button>
       <button 

--- a/src/components/Editor/Footer.tsx
+++ b/src/components/Editor/Footer.tsx
@@ -1,0 +1,35 @@
+import cn from '../../libs/cn';
+
+interface FooterProps {
+  isPostOk: boolean;
+  onPost: () => void;
+  onCancel: () => void;
+}
+
+export default function Footer({isPostOk, onPost, onCancel}: FooterProps) {
+  
+  const handlePostButton = () => {
+    if (isPostOk) {
+      onPost();
+    } else {
+      alert('제목과 내용을 입력해주세요.');
+    }
+  };
+
+  return (
+    <footer className="bg-[#2B5877] flex justify-between">
+      <button onClick={onCancel}>
+        작성취소
+      </button>
+      <button 
+        onClick={handlePostButton}
+        className={cn(
+          "bg-white border rounded-lg p-2",
+          `${isPostOk ? 'text-[#EC6B53] border-[#EC6B53]' : 'text-gray-400 border-gray-400'}`
+        )}
+      >
+        게시하기
+      </button>
+    </footer>
+  );
+}

--- a/src/components/Editor/Search.tsx
+++ b/src/components/Editor/Search.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import SearchBar from './BookReportHeader/SearchBar';
+import SearchResults from './BookReportHeader/SearchResults';
+
+interface SearchProps {
+  setBookIsbn: (isbn: string) => void;
+}
+
+export default function Search({setBookIsbn}: SearchProps) {
+  const [readBookTitle, setReadBookTitle] = useState<string>('');
+  const [searchText, setSearchText] = useState<string>(''); // 검색어 상태 추가
+
+  const handleSearch = (text: string) => {
+    setSearchText(text); 
+  };
+
+  const handleResultClick = (result: string) => {
+    setReadBookTitle(result); 
+    setSearchText(''); 
+  };
+
+  return (
+    <>
+    {/* SearchBar 컴포넌트 */}
+    <SearchBar 
+      readBookTitle={readBookTitle}
+      setReadBookTitle={setReadBookTitle}
+      onSearch={handleSearch}
+    />
+
+    {/* SearchResults 컴포넌트에 검색어 전달 */}
+    <SearchResults 
+      searchText={searchText}
+      onResultClick={handleResultClick}
+      setBookIsbn={setBookIsbn}
+    />
+  </>
+  );
+}

--- a/src/components/Editor/Search.tsx
+++ b/src/components/Editor/Search.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import SearchBar from './BookReportHeader/SearchBar';
 import SearchResults from './BookReportHeader/SearchResults';
 
@@ -9,6 +10,26 @@ interface SearchProps {
 export default function Search({setBookIsbn}: SearchProps) {
   const [readBookTitle, setReadBookTitle] = useState<string>('');
   const [searchText, setSearchText] = useState<string>(''); // 검색어 상태 추가
+
+  const location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
+  const isbnFromUrl = searchParams.get('isbn');
+  const bookTitleFromUrl = searchParams.get('bookTitle');
+
+  useEffect(() => {
+    if (isbnFromUrl) {
+      setBookIsbn(isbnFromUrl);
+      console.log('isbnFromUrl : ', isbnFromUrl);
+    } else {
+      console.log('isbnFromUrl is null');
+    }
+    if (bookTitleFromUrl) {
+      setReadBookTitle(bookTitleFromUrl);
+      console.log('bookTitleFromUrl : ', bookTitleFromUrl);
+    } else {
+      console.log('bookTitleFromUrl is null');
+    }
+  }, [isbnFromUrl, bookTitleFromUrl]);
 
   const handleSearch = (text: string) => {
     setSearchText(text); 

--- a/src/components/common/BookCardComponent.tsx
+++ b/src/components/common/BookCardComponent.tsx
@@ -20,9 +20,7 @@ export default function BookCardComponent({
         src={imageUrl}
         alt="book"
         className={cn(
-          // w-32 md:w-48 lg:w-60 h-40 md:h-60 lg:h-80
-          'aspect-[3/4] relative w-full h-full',
-          'object-cover mb-4 rounded-lg shadow-lg',
+          'w-32 h-40 md:w-48 md:h-60 lg:w-60 lg:h-80 object-cover mb-4 rounded-lg shadow-lg',
           'transform transition duration-300 ease-in-out',
           // 호버 시 크기, 그림자, 위치 변경
           'hover:scale-105 hover:shadow-2xl hover:translate-y-2'

--- a/src/components/common/BookCardComponent.tsx
+++ b/src/components/common/BookCardComponent.tsx
@@ -20,7 +20,9 @@ export default function BookCardComponent({
         src={imageUrl}
         alt="book"
         className={cn(
-          'w-32 h-40 md:w-48 md:h-60 lg:w-60 lg:h-80 object-cover mb-4 rounded-lg shadow-lg',
+          // w-32 md:w-48 lg:w-60 h-40 md:h-60 lg:h-80
+          'aspect-[3/4] relative w-full h-full',
+          'object-cover mb-4 rounded-lg shadow-lg',
           'transform transition duration-300 ease-in-out',
           // 호버 시 크기, 그림자, 위치 변경
           'hover:scale-105 hover:shadow-2xl hover:translate-y-2'

--- a/src/pages/Book.tsx
+++ b/src/pages/Book.tsx
@@ -12,7 +12,14 @@ export default function Book() {
   const { isLogin } = useAuthStore()
 
   const gotoEditor = () => {
-    isLogin ? navigate('/editor') : navigate('/login')
+    if (isLogin) {
+      const url = bookData?.isbn && bookData.title
+        ? `/editor?isbn=${encodeURIComponent(bookData.isbn)}&bookTitle=${encodeURIComponent(bookData.title)}`
+        : '/editor';
+      navigate(url);
+    } else {
+      navigate('/login');
+    }
   }
 
   if (error) {

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -1,14 +1,51 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import BookReportHeader from "../components/Editor/BookReportHeader"
 import TextFiled from "../components/Editor/TextFiled"
+import Footer from "../components/Editor/Footer"
 
 export default function Editor() {
   const [context, setContext] = useState<string>('');
+  const [title, setTitle] = useState<string>(''); 
+  const [thumbnail, setThumbnail] = useState<string>('');
+  const [bookIsbn, setBookIsbn] = useState<string>('');
+  const [isPostOk, setIsPostOk] = useState<boolean>(false);
+
+  const onPost = () => {
+    // 게시하기 버튼 클릭 시 처리
+  }
+
+  const onCancel = () => {
+    // 작성취소 버튼 클릭 시 처리
+  }
+
+  useEffect(() => {
+    if (title && context && bookIsbn) {
+      setIsPostOk(true);
+    } else {
+      setIsPostOk(false);
+    }
+  }
+  , [title, context, bookIsbn]);
 
   return (
     <div>
-      <BookReportHeader />
-      <TextFiled context={context} setContext={setContext}/>
+      <BookReportHeader 
+        title={title}
+        setTitle={setTitle}
+        thumbnail={thumbnail}
+        setThumbnail={setThumbnail}
+        bookIsbn={bookIsbn}
+        setBookIsbn={setBookIsbn}
+      />
+      <TextFiled 
+        context={context}
+        setContext={setContext}
+      />
+      <Footer 
+        isPostOk={isPostOk}
+        onPost={onPost}
+        onCancel={onCancel}
+      />
     </div>
   )
 };

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -12,6 +12,7 @@ export default function Editor() {
   const [isPostOk, setIsPostOk] = useState<boolean>(false);
   const navigate = useNavigate();
 
+
   const onPost = () => {
     // 게시하기 버튼 클릭 시 처리
   }

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -28,19 +28,21 @@ export default function Editor() {
   , [title, context, bookIsbn]);
 
   return (
-    <div>
-      <BookReportHeader 
-        title={title}
-        setTitle={setTitle}
-        thumbnail={thumbnail}
-        setThumbnail={setThumbnail}
-        bookIsbn={bookIsbn}
-        setBookIsbn={setBookIsbn}
-      />
-      <TextFiled 
-        context={context}
-        setContext={setContext}
-      />
+    <div className='min-h-screen'>
+      <main className='pb-[80px]'>
+        <BookReportHeader 
+          title={title}
+          setTitle={setTitle}
+          thumbnail={thumbnail}
+          setThumbnail={setThumbnail}
+          bookIsbn={bookIsbn}
+          setBookIsbn={setBookIsbn}
+        />
+        <TextFiled 
+          context={context}
+          setContext={setContext}
+        />
+      </main>
       <Footer 
         isPostOk={isPostOk}
         onPost={onPost}

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import BookReportHeader from "../components/Editor/BookReportHeader"
 import TextFiled from "../components/Editor/TextFiled"
 import Footer from "../components/Editor/Footer"
@@ -9,13 +10,14 @@ export default function Editor() {
   const [thumbnail, setThumbnail] = useState<string>('');
   const [bookIsbn, setBookIsbn] = useState<string>('');
   const [isPostOk, setIsPostOk] = useState<boolean>(false);
+  const navigate = useNavigate();
 
   const onPost = () => {
     // 게시하기 버튼 클릭 시 처리
   }
 
   const onCancel = () => {
-    // 작성취소 버튼 클릭 시 처리
+    navigate(-1);
   }
 
   useEffect(() => {

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -2,6 +2,7 @@ import cn from "../libs/cn";
 import NoBook from "../components/MyPage/NoBook";
 import BookList from "../components/MyPage/BookList";
 import Pen from '../assets/icons/Pen.svg';
+import { useNavigate } from 'react-router-dom'
 
 export default function MyPage() {
   
@@ -9,6 +10,8 @@ export default function MyPage() {
   const userName = '홍길동';
   let bookCount = 4;
   const bookReportCount = 15;
+
+  const navigate = useNavigate()
 
   return (
     <>
@@ -29,7 +32,9 @@ export default function MyPage() {
           <h2 className="text-xl md:text-2xl lg:text-3xl font-semibold mb-6 md:mb-10 inline">
             내가 읽은 책
           </h2>
-          <button className={cn(
+          <button
+            onClick={() => navigate('/editor')} 
+            className={cn(
             "bg-[#2B5877] text-white px-4 py-2 md:py-3 rounded-lg",
             "text-xs md:text-sm font-semibold mb-6 md:mb-10 flex items-center"
           )}>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #16 

## 📝작업 내용

> - 에디터 페이지와 검색 api 연결하기
> - 클릭한 책의 ISBN 상위 컴포넌트로 넘겨주기
> - 마이페이지에서 글쓰기 클릭 시 에디터창으로 이동
> - ~~Git Revert가 뭔지 몰라서 뻘짓하기~~

## 스크린샷
| 모바일 | 데스크탑 |
|:---:|:---:|
|  ![스크린샷 2024-10-11 오전 12 32 21](https://github.com/user-attachments/assets/3417ab32-d20c-4f6b-9271-e93d0c15a1ad) | ![스크린샷 2024-10-11 오전 12 31 55](https://github.com/user-attachments/assets/c6608adb-d56d-407b-a607-c0b8b931b44d) |
