### PR TITLE
[FIX] - 헤더 QA 반영

### DIFF
--- a/src/components/MainPage/MainPageContext.tsx
+++ b/src/components/MainPage/MainPageContext.tsx
@@ -12,7 +12,7 @@ export default function MainPageContext() {
     <h1 
       className={cn(
         "w-fit text-4xl md:text-6xl xl:text-8xl text-[#2B5877]",
-        "mt-14 md:mt-20 xl:mt-32"
+        "mt-14 md:mt-20 xl:mt-32 cursor-pointer select-none"
       )}
       style={{ letterSpacing: '0.1em' }}
     >
@@ -20,7 +20,7 @@ export default function MainPageContext() {
     </h1>
     <h2 className={cn(
       "w-fit text-base md:text-2xl xl:text-4xl text-[#918F8F]",
-      'mb-6 md:mb-0'
+      'mb-6 md:mb-0 cursor-pointer select-none'
     )}>
       join our community and share your book reviews.
     </h2>

--- a/src/components/auth/AuthHeader.tsx
+++ b/src/components/auth/AuthHeader.tsx
@@ -10,11 +10,11 @@ export default function AuthHeader() {
     >
       <div className="text-center pt-14 md:px-32">
         <div className="flex flex-col items-center mt-6 md:mt-20 gap-6 w-fit font-rockwell font-normal">
-          <h1 className="w-fit text-3xl md:text-5xl xl:text-8xl text-[#2B5877]">
+          <h1 className="w-fit text-3xl md:text-5xl xl:text-8xl text-[#2B5877] cursor-pointer select-none">
             Welcome to BookLog!
           </h1>
-          <h2 className="w-fit text-1xl md:text-2xl xl:text-4xl text-[#918F8F]">
-            Join our community and share your book reviews.
+          <h2 className="w-fit text-1xl md:text-2xl xl:text-4xl text-[#918F8F] cursor-pointer select-none">
+            join our community and share your book reviews.
           </h2>
         </div>
       </div>

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { PiSignIn, PiSignOut } from 'react-icons/pi'
 import cn from '../../../libs/cn.ts'
@@ -9,31 +10,41 @@ interface HeaderProps {
 
 export default function Header({ isBordered }: HeaderProps) {
   const navigate = useNavigate()
+  const [isDropdownOpen, setDropdownOpen] = useState(false)
+  
   const handleLogoClick = () => {
     navigate('/')
   }
+
   const handleUserNameClick = () => {
-    navigate('/mypage')
+    if (window.innerWidth >= 768) {
+      // PC 환경
+      navigate('/mypage')
+    } else {
+      // 모바일 환경
+      setDropdownOpen(!isDropdownOpen)
+    }
   }
+
   const handleLoginClick = () => {
     navigate('/login')
   }
 
-  // 임시로 땜방한 로그인 여부, 유저네임
-  // const isLogin = true
-  // const userName = '홍길동'
+  const handleWriteClick = () => {
+    navigate('/editor')
+  }
 
   const { isLogin, token, logout } = useAuthStore()
 
   return (
     <header
       className={cn(
-        'bg-[#2B5877] text-white p-5 pb-7',
-        `${isBordered && 'fixed w-full rounded-b-3xl z-50'}`
+        'bg-[#2B5877] text-white p-5 ',
+        `${isBordered ? 'fixed w-full rounded-b-3xl z-50' : 'pb-7'}`
       )}
     >
       <div className="flex justify-between mx-0 md:mx-20">
-        <h1 
+        <h1
           onClick={handleLogoClick}
           className="text-3xl font-rockwell font-normal"
           style={{ letterSpacing: '0.1em' }}
@@ -41,17 +52,53 @@ export default function Header({ isBordered }: HeaderProps) {
           Booklog
         </h1>
         {isLogin ? (
-          <div>
+          <div className="relative">
             <span
               onClick={handleUserNameClick}
-              className="mr-4 md:mr-14 text-base md:text-xl"
+              className="mr-4 md:mr-14 text-base md:text-xl cursor-pointer"
             >
               {token} 님
             </span>
+            {/* 드롭다운 메뉴 - 모바일에서만 표시 */}
+            {isDropdownOpen && (
+              <div className={cn(
+                "absolute right-4 mt-2 w-22 bg-white text-black rounded-lg",
+                "shadow-md md:hidden text-center text-sm"
+                )}
+              >
+                <button
+                  onClick={() => {
+                    setDropdownOpen(false)
+                    navigate('/mypage')
+                  }}
+                  className="block w-full px-4 py-2"
+                >
+                  내 블로그
+                </button>
+                <button
+                  onClick={() => {
+                    setDropdownOpen(false)
+                    handleWriteClick()
+                  }}
+                  className="block w-full px-4 py-2 t"
+                >
+                  글쓰기
+                </button>
+                <button
+                  onClick={() => {
+                    setDropdownOpen(false)
+                    logout()
+                  }}
+                  className="block w-full px-4 py-2"
+                >
+                  로그아웃
+                </button>
+              </div>
+            )}
             <button
               onClick={logout}
               className={cn(
-                'bg-white px-3 md:px-4 py-2 rounded-lg text-[#EC6B53] font-bold'
+                'bg-white px-3 md:px-4 py-2 rounded-lg text-[#EC6B53] font-bold hidden md:inline-block'
               )}
             >
               <PiSignOut className="text-base md:text-2xl inline" />

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -63,7 +63,7 @@ export default function Header({ isBordered }: HeaderProps) {
             {isDropdownOpen && (
               <div className={cn(
                 "absolute right-4 mt-2 w-22 bg-white text-black rounded-lg",
-                "shadow-md md:hidden text-center text-sm"
+                "shadow-md md:hidden text-center text-sm z-50"
                 )}
               >
                 <button

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -28,12 +28,16 @@ export default function Header({ isBordered }: HeaderProps) {
   return (
     <header
       className={cn(
-        'bg-[#2B5877] text-white p-5',
+        'bg-[#2B5877] text-white p-5 pb-7',
         `${isBordered && 'fixed w-full rounded-b-3xl z-50'}`
       )}
     >
       <div className="flex justify-between mx-0 md:mx-20">
-        <h1 onClick={handleLogoClick} className="text-3xl ">
+        <h1 
+          onClick={handleLogoClick}
+          className="text-3xl font-rockwell font-normal"
+          style={{ letterSpacing: '0.1em' }}
+        >
           Booklog
         </h1>
         {isLogin ? (

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -46,7 +46,7 @@ export default function Header({ isBordered }: HeaderProps) {
       <div className="flex justify-between mx-0 md:mx-20">
         <h1
           onClick={handleLogoClick}
-          className="text-3xl font-rockwell font-normal"
+          className="text-3xl font-rockwell font-normal cursor-pointer select-none"
           style={{ letterSpacing: '0.1em' }}
         >
           Booklog


### PR DESCRIPTION
## #️⃣연관된 이슈

> #29 

## 📝작업 내용

> - 헤더 폰트 변경
> - 헤더에 바텀 패딩 넣기
> - 모바일에선 로그아웃 버튼 숨기고 드롭다운으로 교체
> - 로그인 페이지 AuthHearder에서 Join을 join으로
> - 북로그, Welcome to Booklog 등 글씨에 드래그 X, 커서 모양도 안바뀌게 수정

### 스크린샷 

![스크린샷 2024-10-11 오후 10 04 14](https://github.com/user-attachments/assets/8b09ffb2-8d88-42d9-9ede-64e2fa509526)

## 💬리뷰 요구사항

> - **브랜치 잘못해서 희진님 qa-login-page 브랜치에 커밋해버렸습니다 ㅠㅠ**
> - 로고나 중요한 글씨에 드래그 안되게 하고, 커서 모양 안바뀌게 하면서 로그인 헤더에도 해당 사항을 적용했으니 확인 바랍니다. + J도 j로 그부분 수정사항도 반영했습니다.
