### PR TITLE
[FEAT] - 책 상세 페이지 중 해당 책의 독후감 리스트 api 연동

### DIFF
--- a/src/hooks/UseBookDetail.ts
+++ b/src/hooks/UseBookDetail.ts
@@ -3,12 +3,16 @@ import { useNavigate } from 'react-router-dom'
 import { fetchBookId } from '../services/BookService.ts'
 import { useBook } from './UseBook'
 import { useCurrentBookState } from '../stores/UseCurrentBookStore.ts'
+import { getReviewsByBookId } from '../services/ReviewService.ts'
+import { ReviewListResponse } from '../model/ReviewListResponse.ts'
+import { ErrorResponse } from '../model/ReviewResponse.ts'
 
 export function useBookDetails() {
   const { bookId, setBookId } = useCurrentBookState()
   const { bookData } = useBook()
   const navigate = useNavigate()
   const [isAccessDenied, setIsAccessDenied] = useState(false)
+  const [isReviewed, setIsReviewed] = useState(false)
 
   useEffect(() => {
     const fetchBookData = async () => {
@@ -21,7 +25,21 @@ export function useBookDetails() {
         } else {
           setIsAccessDenied(false)
           console.log(data)
-          setBookId(data.id)
+          const newBookId = Number(data.id)
+          setBookId(newBookId)
+
+          const reviewsResponse: ReviewListResponse | ErrorResponse =
+            await getReviewsByBookId({
+              bookId: newBookId,
+            })
+
+          if ('reviews' in reviewsResponse) {
+            console.log('리뷰 응답 : ', reviewsResponse.reviews)
+            setIsReviewed(reviewsResponse.reviews.length > 0)
+          } else {
+            console.log('응답 없음 : ', reviewsResponse.message)
+          }
+
           console.log(bookId)
         }
       }
@@ -30,5 +48,9 @@ export function useBookDetails() {
     fetchBookData()
   }, [bookData?.isbn, navigate, setBookId, bookId])
 
-  return { bookData: isAccessDenied ? null : bookData, isAccessDenied }
+  return {
+    bookData: isAccessDenied ? null : bookData,
+    isAccessDenied,
+    isReviewed,
+  }
 }

--- a/src/model/ReviewListRequest.ts
+++ b/src/model/ReviewListRequest.ts
@@ -1,0 +1,3 @@
+export interface ReviewListRequest {
+  bookId: number
+}

--- a/src/model/ReviewListResponse.ts
+++ b/src/model/ReviewListResponse.ts
@@ -1,0 +1,29 @@
+export interface File {
+  id: number
+  logicalName: string
+  physicalPath: string
+}
+
+export interface Book {
+  id: number
+  title: string
+  author: string
+  description: string
+  file: File
+}
+
+export interface Review {
+  id: number
+  title: string
+  content: string
+  name: string
+  userId: string
+  file: File
+  book: Book
+  createAt: string
+  updatedAt: string
+}
+
+export interface ReviewListResponse {
+  reviews: Review[]
+}

--- a/src/pages/Book.tsx
+++ b/src/pages/Book.tsx
@@ -8,7 +8,7 @@ import { useAuthStore } from '../stores/UseCurrentUserStore.ts'
 import { useBookDetails } from '../hooks/UseBookDetail.ts'
 
 export default function Book() {
-  const { bookData, isAccessDenied } = useBookDetails()
+  const { bookData, isAccessDenied, isReviewed } = useBookDetails()
   const navigate = useNavigate()
   const { isLogin } = useAuthStore()
 
@@ -31,12 +31,11 @@ export default function Book() {
 
   useEffect(() => {
     if (!isLogin) {
-      alert('로그인을 해주세요.')
+      alert('로그인을 해주세요')
       navigate('/login')
-      if (isAccessDenied) {
-        alert('서버에 isbn이 없어 페이지에 접근할 수 없습니다.')
-        navigate('/')
-      }
+    } else if (isAccessDenied) {
+      alert('서버에 isbn이 없어 페이지에 접근할 수 없습니다.')
+      navigate('/')
     }
   }, [isLogin, isAccessDenied, navigate])
 
@@ -106,7 +105,7 @@ export default function Book() {
             </div>
           </button>
         </div>
-        {bookData?.isbn === '9791163034735' ? (
+        {isReviewed ? (
           <div className="flex justify-center mt-11">
             <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 mx-auto">
               <Review />

--- a/src/pages/Book.tsx
+++ b/src/pages/Book.tsx
@@ -30,11 +30,15 @@ export default function Book() {
   }
 
   useEffect(() => {
-    if (isAccessDenied) {
-      alert('서버에 isbn이 없어 페이지에 접근할 수 없습니다.')
-      navigate('/')
+    if (!isLogin) {
+      alert('로그인을 해주세요.')
+      navigate('/login')
+      if (isAccessDenied) {
+        alert('서버에 isbn이 없어 페이지에 접근할 수 없습니다.')
+        navigate('/')
+      }
     }
-  }, [isAccessDenied, navigate])
+  }, [isLogin, isAccessDenied, navigate])
 
   return (
     <div>

--- a/src/services/ReviewService.ts
+++ b/src/services/ReviewService.ts
@@ -1,25 +1,38 @@
 import { ReviewMakeFormData } from '../model/ReviewMakeRequest'
 import { ReviewEditFormData } from '../model/ReviewEditRequest'
-import { ReviewSuccessResponse, ErrorResponse, ReviewDetailResponse } from '../model/ReviewResponse'
+import {
+  ReviewSuccessResponse,
+  ErrorResponse,
+  ReviewDetailResponse,
+} from '../model/ReviewResponse'
+import { ReviewListRequest } from '../model/ReviewListRequest'
+import { ReviewListResponse } from '../model/ReviewListResponse'
 import apiClient from '../config/ApiClient'
 
 // 독후감 생성
-export const makeReview = async (data: FormData): Promise<ReviewSuccessResponse | ErrorResponse> => {
+export const makeReview = async (
+  data: FormData
+): Promise<ReviewSuccessResponse | ErrorResponse> => {
   try {
-    const response = await apiClient.post<ReviewSuccessResponse>('/reviews', data, {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
-    });
-    return response.data;
+    const response = await apiClient.post<ReviewSuccessResponse>(
+      '/reviews',
+      data,
+      {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      }
+    )
+    return response.data
   } catch (error) {
-    return handleError(error);
+    return handleError(error)
   }
-};
-
+}
 
 // 독후감 조회
-export const getReview = async (id: number): Promise<ReviewDetailResponse | ErrorResponse> => {
+export const getReview = async (
+  id: number
+): Promise<ReviewDetailResponse | ErrorResponse> => {
   try {
     const response = await apiClient.get<ReviewDetailResponse>(`/reviews/${id}`)
     return response.data
@@ -29,21 +42,30 @@ export const getReview = async (id: number): Promise<ReviewDetailResponse | Erro
 }
 
 // 독후감 수정
-export const editReview = async (reviewId: number, data: FormData): Promise<ReviewDetailResponse | ErrorResponse> => {
+export const editReview = async (
+  reviewId: number,
+  data: FormData
+): Promise<ReviewDetailResponse | ErrorResponse> => {
   try {
-    const response = await apiClient.patch<ReviewDetailResponse>(`/reviews/${reviewId}`, data, {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
-    });
-    return response.data;
+    const response = await apiClient.patch<ReviewDetailResponse>(
+      `/reviews/${reviewId}`,
+      data,
+      {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      }
+    )
+    return response.data
   } catch (error) {
-    return handleError(error);
+    return handleError(error)
   }
-};
+}
 
 // 독후감 삭제
-export const deleteReview = async (reviewId: number): Promise<void | ErrorResponse> => {
+export const deleteReview = async (
+  reviewId: number
+): Promise<void | ErrorResponse> => {
   try {
     await apiClient.patch(`/reviews/delete/${reviewId}`)
   } catch (error) {
@@ -63,5 +85,18 @@ const handleError = (error: any): ErrorResponse => {
       code: '500',
       message: '서버와 연결할 수 없습니다.',
     }
+  }
+}
+
+export const getReviewsByBookId = async (
+  request: ReviewListRequest
+): Promise<ReviewListResponse | ErrorResponse> => {
+  try {
+    const response = await apiClient.get<ReviewListResponse>(
+      `/reviews/lists/${request.bookId}`
+    )
+    return response.data
+  } catch (error) {
+    return handleError(error)
   }
 }

--- a/src/stores/UseCurrentBookStore.ts
+++ b/src/stores/UseCurrentBookStore.ts
@@ -1,8 +1,8 @@
 import { create } from 'zustand'
 
 interface CurrentBookState {
-  bookId: string | null
-  setBookId: (bookId: string | null) => void
+  bookId: number | null
+  setBookId: (bookId: number | null) => void
 }
 
 export const useCurrentBookState = create<CurrentBookState>((set) => ({


### PR DESCRIPTION
## #️⃣연관된 이슈

> #45 

## 📝작업 내용

> 책의 독후감 api를 연동하였습니다.
> 아직 독후감 데이터가 있는 책이 없어, 독후감이 없는 경우만 출력됩니다.

### 스크린샷

> ![무제](https://github.com/user-attachments/assets/f144f18f-cd53-4934-a431-751b0bd7ed34)

## 💬리뷰 요구사항

> 와이어 프레임상 책 상세 페이지 내부 데이터는 로그인 유무와 관계없이 모두 확인 가능하여야 합니다. 현재 isbn 기반 bookId 반환 api에서 로그인을 요구하고 있기에 알럿으로 처리해 두었고, 백엔드 분들께 api 수정 요청드린 상황입니다!
> 잘 동작하는지 확인 부탁드립니다.  
