### PR TITLE
[FIX] - 책 상세 api 관련 수정

### DIFF
--- a/src/config/ApiClient.ts
+++ b/src/config/ApiClient.ts
@@ -10,7 +10,8 @@ apiClient.interceptors.request.use(
     if (
       config.url &&
       !config.url.includes('/login') &&
-      !config.url.includes('/register')
+      !config.url.includes('/register') &&
+      !config.url.includes('/book')
     ) {
       const { accessToken } = useAuthStore.getState()
       // console.log('Access Token:', accessToken) // 토큰 출력

--- a/src/config/ApiClient.ts
+++ b/src/config/ApiClient.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 import { useAuthStore } from '../stores/UseCurrentUserStore'
 
 const apiClient = axios.create({
-  baseURL: 'http://58.238.255.245:8080/api/v1',
+  baseURL: 'https://api-booklog.ezbooks.kr/api/v1',
 })
 
 apiClient.interceptors.request.use(

--- a/src/pages/Book.tsx
+++ b/src/pages/Book.tsx
@@ -30,14 +30,11 @@ export default function Book() {
   }
 
   useEffect(() => {
-    if (!isLogin) {
-      alert('로그인을 해주세요')
-      navigate('/login')
-    } else if (isAccessDenied) {
+    if (isAccessDenied) {
       alert('서버에 isbn이 없어 페이지에 접근할 수 없습니다.')
       navigate('/')
     }
-  }, [isLogin, isAccessDenied, navigate])
+  }, [isAccessDenied, navigate])
 
   return (
     <div>

--- a/src/services/ReviewService.ts
+++ b/src/services/ReviewService.ts
@@ -93,7 +93,7 @@ export const getReviewsByBookId = async (
 ): Promise<ReviewListResponse | ErrorResponse> => {
   try {
     const response = await apiClient.get<ReviewListResponse>(
-      `/reviews/lists/${request.bookId}`
+      `/reviews/list/${request.bookId}`
     )
     return response.data
   } catch (error) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #45 

## 📝작업 내용

> 로그인 유무에 관계없이 책 상세 페이지에 접근이 가능합니다.
> api 엔드포인트명 변경사항 반영하였습니다.
> 서버 SSL 인증서 발급 사항 반영하였습니다.

### 스크린샷 

> ![image](https://github.com/user-attachments/assets/4576eec6-f76c-41c4-bd22-1e8f270ba96a)

## 💬리뷰 요구사항

> 현재는 책에 대한 독후감 리스트가 있으면 더미 데이터로 제작된 컴포넌트가 보이고 있습니다. 
> 해당 브랜치 커밋 후 독후감 api 연동 진행하겠습니다!