### PR TITLE
[FIX] - 로그인 완료 후 페이지 이동

### DIFF
--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -4,13 +4,14 @@ import AuthBtn from './AuthBtn'
 import { AuthCredentials } from '../../model/AuthCredentials'
 import User from '../../assets/icons/User.svg'
 import Lock from '../../assets/icons/Lock.svg'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
 import { login } from '../../services/AuthService'
 import { LoginRequest } from '../../model/LoginRequest'
 import { useAuthStore } from '../../stores/UseCurrentUserStore'
 
 export default function LoginForm() {
   const navigate = useNavigate()
+  const location = useLocation()
   const { setUsername, setAccessToken, setRefreshToken } = useAuthStore()
 
   const {
@@ -28,13 +29,14 @@ export default function LoginForm() {
 
   const onSubmit = async (data: AuthCredentials) => {
     const loginRequestData = toLoginRequest(data)
+    const from = location.state?.from || '/'
 
     try {
       const response = await login(loginRequestData)
       setAccessToken(response.accessToken)
       setRefreshToken(response.refreshToken)
       setUsername(loginRequestData.id)
-      navigate(-1)
+      navigate(from)
     } catch (error) {
       console.error('로그인 에러:', error)
     }

--- a/src/pages/Book.tsx
+++ b/src/pages/Book.tsx
@@ -20,7 +20,9 @@ export default function Book() {
           : '/editor'
       navigate(url)
     } else if (!isLogin) {
-      navigate('/requestLogin', { state: { from: location.pathname } })
+      navigate('/requestLogin', {
+        state: { from: location.pathname, action: '작성' },
+      })
     }
   }
 
@@ -28,7 +30,9 @@ export default function Book() {
     const articleSlug = id.toString()
 
     if (!isLogin) {
-      navigate('/requestLogin', { state: { from: location.pathname } })
+      navigate('/requestLogin', {
+        state: { from: location.pathname, action: '감상' },
+      })
     } else {
       navigate(`/article/${articleSlug}`)
     }

--- a/src/pages/Book.tsx
+++ b/src/pages/Book.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
 import Review from '../components/book/Review.tsx'
 import { getDisplayAuthor } from '../libs/AuthorUtils'
 import cn from '../libs/cn.ts'
@@ -8,7 +8,7 @@ import { useAuthStore } from '../stores/UseCurrentUserStore.ts'
 import { useBookDetails } from '../hooks/UseBookDetail.ts'
 
 export default function Book() {
-  const { bookData, isAccessDenied, isReviewed, reviews } = useBookDetails() // 리뷰 데이터 가져오기
+  const { bookData, isAccessDenied, isReviewed, reviews } = useBookDetails()
   const navigate = useNavigate()
   const { isLogin } = useAuthStore()
 
@@ -19,8 +19,8 @@ export default function Book() {
           ? `/editor?isbn=${encodeURIComponent(bookData.isbn)}&bookTitle=${encodeURIComponent(bookData.title)}`
           : '/editor'
       navigate(url)
-    } else {
-      navigate('/login')
+    } else if (!isLogin) {
+      navigate('/requestLogin', { state: { from: location.pathname } })
     }
   }
 
@@ -28,7 +28,7 @@ export default function Book() {
     const articleSlug = id.toString()
 
     if (!isLogin) {
-      navigate('/requestLogin')
+      navigate('/requestLogin', { state: { from: location.pathname } })
     } else {
       navigate(`/article/${articleSlug}`)
     }

--- a/src/pages/RequestLogin.tsx
+++ b/src/pages/RequestLogin.tsx
@@ -11,6 +11,7 @@ export default function RequestLogin() {
   const { isLogin } = useAuthStore()
 
   const from = location.state?.from || '/'
+  const action = location.state?.action || '작성'
 
   useEffect(() => {
     if (isLogin) {
@@ -33,7 +34,8 @@ export default function RequestLogin() {
             className="w-[175.48px] md:w-[327px] h-[182.45px] md:h-[340px] mx-[67.76px] md:mx-auto object-contain"
           />
           <p className="text-[#4e4d4d] text-xs sm:text-2xl pt-[41.23px] sm:pt-[77px] text-center text-nowrap">
-            독후감을 작성하려면 <span className="text-[#EC6B53]">로그인</span>
+            독후감을 {action}하려면
+            <span className="text-[#EC6B53]">로그인</span>
             해주세요!
           </p>
         </div>

--- a/src/pages/RequestLogin.tsx
+++ b/src/pages/RequestLogin.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
 import MainPageContext from '../components/MainPage/MainPageContext'
 import SampleReviewImg from '../assets/images/SampleReviewImg.svg'
 import cn from '../libs/cn'
@@ -7,17 +7,20 @@ import { useAuthStore } from '../stores/UseCurrentUserStore'
 
 export default function RequestLogin() {
   const navigate = useNavigate()
+  const location = useLocation()
   const { isLogin } = useAuthStore()
 
-  const gotoLogin = () => {
-    navigate('/login')
-  }
+  const from = location.state?.from || '/'
 
   useEffect(() => {
     if (isLogin) {
-      navigate(-1)
+      navigate(from)
     }
-  }, [isLogin, navigate])
+  }, [isLogin, from, navigate])
+
+  const gotoLogin = () => {
+    navigate('/login', { state: { from } })
+  }
 
   return (
     <>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #29 #52 

## 📝작업 내용

> 로그인 완료 후 로그인에 진입했던 초기 페이지로 이동합니다.
> 로그인 요청 페이지로 이동할 때 액션을 함께 전달하여 두 가지 버전의 텍스트를 출력합니다.

### 스크린샷 

> ![무제](https://github.com/user-attachments/assets/39f72be8-75ef-4910-8109-fb9f3c32e083)

## 💬리뷰 요구사항

> 
